### PR TITLE
为名称包含特殊字符的触发器类别与常量字符串添加引号

### DIFF
--- a/script/core/slk/backend_lml.lua
+++ b/script/core/slk/backend_lml.lua
@@ -25,11 +25,11 @@ local sp_rep = setmetatable({}, {
 
 local function lml_string(str)
     if type(str) == 'string' then
-		-- Check string from WTS firstly.
-		if find(str, '^TRIGSTR_%d+$') then
+        -- Check string from WTS firstly.
+        if find(str, '^TRIGSTR_%d+$') then
             str = w2l:load_wts(wts, str)
         end
-		-- Then check if the string should be in quotes.
+        -- Then check if the string should be in quotes.
         if find(str, "[%s%:%'%c]") then
             str = format("'%s'", gsub(str, "'", "''"))
         end


### PR DESCRIPTION
修复问题 #17 
为触发器类别专门添加一个lml_string_without_wts是为了防止有人无聊将类别命名为TRIGSTR_xxx然后搞崩掉程序,虽然没理由这样做,但既然WE允许这样做,那w3x2lni也就这样兼容吧 🎃 