### PR TITLE
Fix w3i error for 1.32 maps

### DIFF
--- a/script/core/slk/backend_w3i.lua
+++ b/script/core/slk/backend_w3i.lua
@@ -46,6 +46,7 @@ function mt:read_head(data, version)
     data.player_rec = self:get(lang.w3i.PLAYER_DESC)
     data.script_type= self:get(lang.w3i.SCRIPT_TYPE)
     data.unknown_10 = self:get(lang.w3i.UNKNOWN_10)
+    data.unknown_11 = self:get(lang.w3i.UNKNOWN_11)
 
     self:current(lang.w3i.CAMERA)
     for i = 1, 8 do
@@ -139,6 +140,8 @@ function mt:read_player(data)
         player.start_y        = self:get(lang.w3i.START_POSITION)[2]
         player.ally_low_flag  = pack_flag(self:get(lang.w3i.ALLY_LOW_FLAG))
         player.ally_high_flag = pack_flag(self:get(lang.w3i.ALLY_HIGH_FLAG))
+        player.unknown_12     = self:get(lang.w3i.UNKNOWN_12)
+        player.unknown_13     = self:get(lang.w3i.UNKNOWN_13)
     end
 end
 
@@ -289,7 +292,8 @@ function mt:add_head(data, version)
         end
 
         if version >= 31 then
-          self:add('i8', data.unknown_10)
+            self:add('l', data.unknown_10)
+            self:add('l', data.unknown_11)
         end
     elseif version == 18 then
         self:add('lzzz', data.loading_screen_id, data.loading_screen_text, data.loading_screen_title, data.loading_screen_subtitle)
@@ -307,7 +311,7 @@ function mt:add_player(data)
         --player.ally_low_flag = player.ally_low_flag | ((1 << data.player_count) - 1)
         --player.ally_high_flag = player.ally_high_flag | ((1 << data.player_count) - 1)
 
-        self:add('llllzffLLi8', player.id, player.type, player.race, player.start_position, player.name, player.start_x, player.start_y, player.ally_low_flag, player.ally_high_flag, player.unknown_11)
+        self:add('llllzffLLll', player.id, player.type, player.race, player.start_position, player.name, player.start_x, player.start_y, player.ally_low_flag, player.ally_high_flag, player.unknown_12, player.unknown_13)
     end
 end
 

--- a/script/core/slk/backend_w3i.lua
+++ b/script/core/slk/backend_w3i.lua
@@ -45,6 +45,7 @@ function mt:read_head(data, version)
     data.des        = self:get(lang.w3i.MAP_DESC)
     data.player_rec = self:get(lang.w3i.PLAYER_DESC)
     data.script_type= self:get(lang.w3i.SCRIPT_TYPE)
+    data.unknown_10 = self:get(lang.w3i.UNKNOWN_10)
 
     self:current(lang.w3i.CAMERA)
     for i = 1, 8 do
@@ -286,6 +287,10 @@ function mt:add_head(data, version)
         if version >= 28 then
             self:add('l', data.script_type:lower() == 'lua' and 1 or 0)
         end
+
+        if version >= 31 then
+          self:add('i8', data.unknown_10)
+        end
     elseif version == 18 then
         self:add('lzzz', data.loading_screen_id, data.loading_screen_text, data.loading_screen_title, data.loading_screen_subtitle)
 
@@ -302,7 +307,7 @@ function mt:add_player(data)
         --player.ally_low_flag = player.ally_low_flag | ((1 << data.player_count) - 1)
         --player.ally_high_flag = player.ally_high_flag | ((1 << data.player_count) - 1)
 
-        self:add('llllzffLL', player.id, player.type, player.race, player.start_position, player.name, player.start_x, player.start_y, player.ally_low_flag, player.ally_high_flag)
+        self:add('llllzffLLi8', player.id, player.type, player.race, player.start_position, player.name, player.start_x, player.start_y, player.ally_low_flag, player.ally_high_flag, player.unknown_11)
     end
 end
 
@@ -330,7 +335,7 @@ end
 
 function mt:add_tech(data)
     self:add('l', data.tech_count)
-    
+
     for i = 1, data.tech_count do
         local tech = data.techs[i]
 
@@ -347,7 +352,7 @@ function mt:add_randomgroup(data)
         self:add('lz', group.id, group.name)
 
         self:add('l', group.position_count)
-        
+
         for i = 1, group.position_count do
             self:add('l', group.positions[i])
         end
@@ -407,7 +412,7 @@ return function (self, data, wts)
         tbl:read_tech(data)
         tbl:read_randomgroup(data)
         tbl:read_randomitem(data)
-    
+
         tbl:add_head(data, version)
         tbl:add_player(data)
         tbl:add_force(data)
@@ -422,7 +427,7 @@ return function (self, data, wts)
         tbl:read_upgrade(data)
         tbl:read_tech(data)
         tbl:read_randomgroup(data)
-    
+
         tbl:add_head(data, version)
         tbl:add_player(data)
         tbl:add_force(data)

--- a/script/core/slk/backend_w3i2lni.lua
+++ b/script/core/slk/backend_w3i2lni.lua
@@ -137,6 +137,7 @@ function mt:add_head(data)
     self:value(lang.w3i.SOUND)
     self:value(lang.w3i.LIGHT)
     self:value(lang.w3i.WATER_COLOR)
+    self:value(lang.w3i.UNKNOWN_10)
 
     return data
 end
@@ -155,6 +156,7 @@ function mt:add_player(data)
         self:value(lang.w3i.START_POSITION)
         self:value(lang.w3i.ALLY_LOW_FLAG)
         self:value(lang.w3i.ALLY_HIGH_FLAG)
+        self:value(lang.w3i.UNKNOWN_11)
     end
 end
 

--- a/script/core/slk/backend_w3i2lni.lua
+++ b/script/core/slk/backend_w3i2lni.lua
@@ -77,6 +77,7 @@ function mt:add_head(data)
     self:value(lang.w3i.PLAYER_DESC)
     self:value(lang.w3i.SCRIPT_TYPE)
     self:value(lang.w3i.UNKNOWN_10)
+    self:value(lang.w3i.UNKNOWN_11)
 
     self:title(lang.w3i.CAMERA, data)
     self:value(lang.w3i.CAMERA_BOUND)

--- a/script/core/slk/backend_w3i2lni.lua
+++ b/script/core/slk/backend_w3i2lni.lua
@@ -157,7 +157,8 @@ function mt:add_player(data)
         self:value(lang.w3i.START_POSITION)
         self:value(lang.w3i.ALLY_LOW_FLAG)
         self:value(lang.w3i.ALLY_HIGH_FLAG)
-        self:value(lang.w3i.UNKNOWN_11)
+        self:value(lang.w3i.UNKNOWN_12)
+        self:value(lang.w3i.UNKNOWN_13)
     end
 end
 

--- a/script/core/slk/backend_w3i2lni.lua
+++ b/script/core/slk/backend_w3i2lni.lua
@@ -76,6 +76,7 @@ function mt:add_head(data)
     self:value(lang.w3i.MAP_DESC)
     self:value(lang.w3i.PLAYER_DESC)
     self:value(lang.w3i.SCRIPT_TYPE)
+    self:value(lang.w3i.UNKNOWN_10)
 
     self:title(lang.w3i.CAMERA, data)
     self:value(lang.w3i.CAMERA_BOUND)
@@ -137,7 +138,6 @@ function mt:add_head(data)
     self:value(lang.w3i.SOUND)
     self:value(lang.w3i.LIGHT)
     self:value(lang.w3i.WATER_COLOR)
-    self:value(lang.w3i.UNKNOWN_10)
 
     return data
 end

--- a/script/core/slk/frontend_w3i.lua
+++ b/script/core/slk/frontend_w3i.lua
@@ -144,14 +144,14 @@ function mt:add_head(chunk, version)
             [lang.w3i.WATER_COLOR] = pack(self:unpack 'BBBB'),
         }
 
-        -- Unknown 8 bytes added in 1.32
-        if version >= 31 then
-            chunk[lang.w3i.ENVIRONMENT][lang.w3i.UNKNOWN_10] = self:unpack 'i8'
-        end
-
         if version >= 28 then
             local scriptType = self:unpack 'l'
             chunk[lang.w3i.MAP][lang.w3i.SCRIPT_TYPE] = scriptType == 0 and 'JASS' or 'Lua'
+        end
+
+        -- Unknown 8 bytes added in 1.32
+        if version >= 31 then
+            chunk[lang.w3i.ENVIRONMENT][lang.w3i.UNKNOWN_10] = self:unpack 'i8'
         end
     elseif version == 18 then
         chunk[lang.w3i.LOADING_SCREEN] = {

--- a/script/core/slk/frontend_w3i.lua
+++ b/script/core/slk/frontend_w3i.lua
@@ -151,7 +151,8 @@ function mt:add_head(chunk, version)
 
         -- Unknown 8 bytes added in 1.32
         if version >= 31 then
-            chunk[lang.w3i.MAP][lang.w3i.UNKNOWN_10] = self:unpack 'i8'
+            chunk[lang.w3i.MAP][lang.w3i.UNKNOWN_10] = self:unpack 'l'
+            chunk[lang.w3i.MAP][lang.w3i.UNKNOWN_11] = self:unpack 'l'
         end
     elseif version == 18 then
         chunk[lang.w3i.LOADING_SCREEN] = {
@@ -188,7 +189,9 @@ function mt:add_player(chunk, version)
         }
 
         if version >= 31 then
-            chunk[lang.w3i.PLAYER..i][lang.w3i.UNKNOWN_11] = self:unpack 'i8' -- Unknown added in 1.32
+            -- Unknown added in 1.32
+            chunk[lang.w3i.PLAYER..i][lang.w3i.UNKNOWN_12] = self:unpack 'l'
+            chunk[lang.w3i.PLAYER..i][lang.w3i.UNKNOWN_13] = self:unpack 'l'
         end
     end
 end

--- a/script/core/slk/frontend_w3i.lua
+++ b/script/core/slk/frontend_w3i.lua
@@ -144,13 +144,14 @@ function mt:add_head(chunk, version)
             [lang.w3i.WATER_COLOR] = pack(self:unpack 'BBBB'),
         }
 
+        -- Unknown 8 bytes added in 1.32
+        if version >= 31 then
+            chunk[lang.w3i.ENVIRONMENT][lang.w3i.UNKNOWN_10] = self:unpack 'i8'
+        end
+
         if version >= 28 then
             local scriptType = self:unpack 'l'
             chunk[lang.w3i.MAP][lang.w3i.SCRIPT_TYPE] = scriptType == 0 and 'JASS' or 'Lua'
-
-            if version >= 31 then
-                self:unpack 'i8' -- Unknown added in 1.32
-            end
         end
     elseif version == 18 then
         chunk[lang.w3i.LOADING_SCREEN] = {
@@ -187,7 +188,7 @@ function mt:add_player(chunk, version)
         }
 
         if version >= 31 then
-            self:unpack 'i8' -- Unknown added in 1.32
+            chunk[lang.w3i.PLAYER..i][lang.w3i.UNKNOWN_11] = self:unpack 'i8' -- Unknown added in 1.32
         end
     end
 end

--- a/script/core/slk/frontend_w3i.lua
+++ b/script/core/slk/frontend_w3i.lua
@@ -151,7 +151,7 @@ function mt:add_head(chunk, version)
 
         -- Unknown 8 bytes added in 1.32
         if version >= 31 then
-            chunk[lang.w3i.ENVIRONMENT][lang.w3i.UNKNOWN_10] = self:unpack 'i8'
+            chunk[lang.w3i.MAP][lang.w3i.UNKNOWN_10] = self:unpack 'i8'
         end
     elseif version == 18 then
         chunk[lang.w3i.LOADING_SCREEN] = {

--- a/script/core/slk/frontend_w3i.lua
+++ b/script/core/slk/frontend_w3i.lua
@@ -147,6 +147,10 @@ function mt:add_head(chunk, version)
         if version >= 28 then
             local scriptType = self:unpack 'l'
             chunk[lang.w3i.MAP][lang.w3i.SCRIPT_TYPE] = scriptType == 0 and 'JASS' or 'Lua'
+
+            if version >= 31 then
+                self:unpack 'i8' -- Unknown added in 1.32
+            end
         end
     elseif version == 18 then
         chunk[lang.w3i.LOADING_SCREEN] = {
@@ -165,7 +169,7 @@ function mt:add_head(chunk, version)
     end
 end
 
-function mt:add_player(chunk)
+function mt:add_player(chunk, version)
     chunk[lang.w3i.PLAYER] = {
         [lang.w3i.PLAYER_COUNT] = self:unpack 'l',
     }
@@ -181,6 +185,10 @@ function mt:add_player(chunk)
             [lang.w3i.ALLY_LOW_FLAG]      = unpack_flag(self:unpack 'L'),
             [lang.w3i.ALLY_HIGH_FLAG]     = unpack_flag(self:unpack 'L'),
         }
+
+        if version >= 31 then
+            self:unpack 'i8' -- Unknown added in 1.32
+        end
     end
 end
 
@@ -317,7 +325,7 @@ return function (w2l_, content, wts)
     local version = tbl:get_version(data)
     if version >= 25 then
         tbl:add_head(data, version)
-        tbl:add_player(data)
+        tbl:add_player(data, version)
         tbl:add_force(data)
         tbl:add_upgrade(data)
         tbl:add_tech(data)
@@ -325,7 +333,7 @@ return function (w2l_, content, wts)
         tbl:add_randomitem(data)
     elseif version == 18 then
         tbl:add_head(data, version)
-        tbl:add_player(data)
+        tbl:add_player(data, version)
         tbl:add_force(data)
         tbl:add_upgrade(data)
         tbl:add_tech(data)

--- a/script/locale/enUS/w3i.lng
+++ b/script/locale/enUS/w3i.lng
@@ -84,6 +84,10 @@ unknown_9
 unknown_10
 [UNKNOWN_11]
 unknown_11
+[UNKNOWN_12]
+unknown_12
+[UNKNOWN_13]
+unknown_13
 [LOADING_SCREEN]
 loading_screen
 [ID]

--- a/script/locale/enUS/w3i.lng
+++ b/script/locale/enUS/w3i.lng
@@ -80,6 +80,10 @@ unknown_7
 unknown_8
 [UNKNOWN_9]
 unknown_9
+[UNKNOWN_10]
+unknown_10
+[UNKNOWN_11]
+unknown_11
 [LOADING_SCREEN]
 loading_screen
 [ID]

--- a/script/locale/zhCN/w3i.lng
+++ b/script/locale/zhCN/w3i.lng
@@ -84,6 +84,10 @@
 未知10
 [UNKNOWN_11]
 未知11
+[UNKNOWN_12]
+未知12
+[UNKNOWN_13]
+未知13
 [LOADING_SCREEN]
 载入图
 [ID]

--- a/script/locale/zhCN/w3i.lng
+++ b/script/locale/zhCN/w3i.lng
@@ -80,6 +80,10 @@
 未知8
 [UNKNOWN_9]
 未知9
+[UNKNOWN_10]
+未知10
+[UNKNOWN_11]
+未知11
 [LOADING_SCREEN]
 载入图
 [ID]


### PR DESCRIPTION
For maps saved in the 1.32 editor 8 bytes were added after the header as well as 8 bytes after each player data.

Fixes https://github.com/sumneko/w3x2lni/issues/57

I assume you'd want to store these somewhere but I'm not familiar with this project yet so feel free to edit.

// Edit: added unknown 10-13, no idea if something else needs to be done besides this.