### PR TITLE
使gui和w2l支持使用>2GB的内存地址以解决内存可能不足的问题

### DIFF
--- a/make.lua
+++ b/make.lua
@@ -11,6 +11,7 @@ lm:executable 'w3x2lni' {
         'w3x2lni/main_gui.cpp',
         'w3x2lni/common.cpp',
     },
+    ldflags = '/largeaddressaware',
     crt = 'static'
 }
 
@@ -26,7 +27,7 @@ lm:executable 'w2l' {
         'unicode.cpp',
     },
     links = "delayimp",
-    ldflags = '/DELAYLOAD:lua54.dll',
+    ldflags = {'/DELAYLOAD:lua54.dll','/largeaddressaware'},
     crt = 'static'
 }
 


### PR DESCRIPTION
为两个可执行文件的链接器参数添加'/largeaddressaware'以支持大地址。
见 #87
如同在给YDWE中的PR中所说的，造成“not enough memory”的问题究竟是“内存不足”还是“连续内存不足”？
因为在实测中，确实没有没有观察到w2l有使用超过2G的内存。
经过测试，在启用大地址后，not enough memory”的问题确实是被解决了，故提个PR，也许未来有更好的解决方案。